### PR TITLE
inline editor and image holder changes

### DIFF
--- a/RubyBlueTheme.less
+++ b/RubyBlueTheme.less
@@ -177,9 +177,14 @@
     }
 }
 
-/* Quick Docs & Quick Edit */
+/* Non-editor styling */
 
-.inline-widget {
-    background-color: #d1d1d1;
-    color: #333;
+#image-holder,
+#not-editor {
+    background-color: #112435;
 }
+
+#image-holder {
+    color: #fff;
+}
+


### PR DESCRIPTION
I made a couple of changes as I was unable to read some of the code in an inline editor due to the very light background.  The core team has made a default styling for inline editors if `dark: true` is specified.  Unless you want to get into a bunch of changes with many little styles, it seems best to just rely on the default styling for your inline editors.

Also, changed `#image-holder` so that the image viewer (which doesn't have default styling from core yet) reflects your theme colors.
